### PR TITLE
Updated to work with UE4.24.

### DIFF
--- a/Source/VictoryUMG/Private/JoyColorWheel.cpp
+++ b/Source/VictoryUMG/Private/JoyColorWheel.cpp
@@ -5,8 +5,9 @@
 	
 	copyright 2015
 */
-#include "VictoryUMGPrivatePCH.h"
 #include "JoyColorWheel.h"
+#include "VictoryUMGPrivatePCH.h"
+
  
 //LOCTEXT
 #define LOCTEXT_NAMESPACE "UMG"

--- a/Source/VictoryUMG/Public/SJoyColorPicker.h
+++ b/Source/VictoryUMG/Public/SJoyColorPicker.h
@@ -11,7 +11,7 @@
 //UE4 Color Picker
 //		Requires public module in build.cs
 //			APPFRAMEWORK 
-#include "SColorPicker.h"
+#include "Widgets/Colors/SColorPicker.h"
   
 class SJoyColorPicker
 	: public SColorPicker

--- a/Source/VictoryUMG/VictoryUMG.Build.cs
+++ b/Source/VictoryUMG/VictoryUMG.Build.cs
@@ -21,9 +21,8 @@ public class VictoryUMG : ModuleRules
 				"RenderCore",		 
 				"UMG", 
 				"Slate", 
-				"SlateCore", 
-                "APPFRAMEWORK" //for color picker! -Rama
-		
+				"SlateCore",
+				"AppFramework" //				"APPFRAMEWORK" //for color picker! -Rama
 			}
 		);
 		

--- a/VictoryUMG.uplugin
+++ b/VictoryUMG.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion" : 3,
 	"Version" : 1,
-	"VersionName" : "1.0",
+	"VersionName" : "1.1",
 	"FriendlyName" : "Victory UMG",
 	"Description" : "Rama's UMG Widgets for You!",
 	"Category" : "Victory Plugin",
@@ -24,8 +24,7 @@
 			"WhitelistPlatforms" :
 			[
 				"Win64",
-				"Win32",
-				"HTML5"
+				"Win32"
 			]
 		}
 	]


### PR DESCRIPTION
It looks like this plugin stopped working with modern versions of UE4 quite some time ago (judging by the GitHub Issues). Either way, I found that it didn't compile for UE 4.24, so I updated it to work with that version (for one of my projects).

Removed obsolete "HTML5" platform, changed header include order, and corrected include path.
